### PR TITLE
Renaming lwwes to lww

### DIFF
--- a/lww.go
+++ b/lww.go
@@ -1,0 +1,12 @@
+/*
+Package lww implements a Last-Writer-Wins (LWW) Element Set data structure.
+
+In distributed computing, a conflict-free replicated data type (CRDT) is a type of specially-designed data structure used to achieve strong eventual consistency (SEC) and monotonicity (absence of rollbacks).
+
+One type of data structure used in implementing CRDT is LWW-element-set.
+
+LWW-element-set is a set that its elements have timestamp. Add and remove will save the timestamp along with data in two different sets for each element.
+
+Queries over LWW-set will check both add and remove timestamps to decide about state of each element is being existed to removed from the list.
+*/
+package lww

--- a/lww_test.go
+++ b/lww_test.go
@@ -1,0 +1,1 @@
+package lww


### PR DESCRIPTION
Starting to type lwwes I found es part makes it too long and lww is as good an abbreviate as lwwes.