### PR TITLE
Renaming lwwes to lww

### DIFF
--- a/lww.go
+++ b/lww.go
@@ -9,4 +9,4 @@ LWW-element-set is a set that its elements have timestamp. Add and remove will s
 
 Queries over LWW-set will check both add and remove timestamps to decide about state of each element is being existed to removed from the list.
 */
-package lwwes
+package lww

--- a/lww_test.go
+++ b/lww_test.go
@@ -1,0 +1,1 @@
+package lww

--- a/lwwes_test.go
+++ b/lwwes_test.go
@@ -1,1 +1,0 @@
-package lwwes


### PR DESCRIPTION
Starting to type lwwes I found es part makes it too long and lww is as good an abbreviate as lwwes.